### PR TITLE
feat(package): add sideEffects prop for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"homepage": "https://github.com/vanruesc/math-ds",
 	"main": "build/math-ds.js",
 	"module": "src/index.js",
+	"sideEffects": false,
 	"license": "Zlib",
 
 	"keywords": [


### PR DESCRIPTION
This will improve tree-shaking in webpack 4 environments, thus shrink up final bundle for a few kb's.

Related:
https://webpack.js.org/guides/tree-shaking
https://github.com/webpack/webpack/tree/master/examples/side-effects